### PR TITLE
Handle OAuth flow without system browser

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -69,7 +69,21 @@ function connectSSE(){
 document.getElementById("refresh").onclick = loadEmails;
 document.getElementById("ask").onclick = ask;
 document.getElementById("enableNotifs").onclick = enableNotifs;
-document.getElementById("connect").onclick = ()=> jget("/auth/start").then(()=>alert("If prompted, complete Google login in the new tab.")).catch(e=>alert(e.message));
+document.getElementById("connect").onclick = () =>
+  jget("/auth/start")
+    .then(res => {
+      if(res.already_authenticated){
+        alert("Gmail is already connected.");
+        return;
+      }
+      if(res.auth_url){
+        window.open(res.auth_url, "_blank", "noopener,noreferrer");
+        alert("Complete Google login in the opened tab, then return here.");
+        return;
+      }
+      alert("Authentication response received.");
+    })
+    .catch(e => alert(e.message));
 
 loadEmails();
 connectSSE();


### PR DESCRIPTION
## Summary
- add a headless-friendly Gmail OAuth flow that exposes start and callback helpers instead of opening a local browser
- surface new /auth/start and /auth/callback logic in the API so the frontend can launch the consent screen and persist tokens
- update the Connect Gmail button to open the returned authorization URL and guide the user through completing login

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68c9bf0dcb6c8325847d5161a4aa8426