### PR TITLE
Switch Gemini default to 2.5 Flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small local app that watches your Gmail, classifies new emails with Google Gem
 
 ## What you get
 
-- FastAPI backend that polls Gmail and classifies with Gemini 1.5 Pro (override via `GOOGLE_GENAI_MODEL`)
+- FastAPI backend that polls Gmail and classifies with Gemini 2.5 Flash (override via `GOOGLE_GENAI_MODEL`)
 - SQLite storage of parsed emails
 - SSE stream that triggers browser notifications for important emails or replies needed
 - Simple web UI with a chat style Q&A box

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -13,7 +13,7 @@ REPLY_IMPORTANCE_THRESHOLD=0.6
 REPLY_NEEDED_THRESHOLD=0.6
 
 # Optional overrides
-# GOOGLE_GENAI_MODEL=gemini-1.5-pro
+# GOOGLE_GENAI_MODEL=gemini-2.5-flash
 
 # CORS
 CORS_ORIGINS=http://localhost:5173

--- a/backend/triage.py
+++ b/backend/triage.py
@@ -9,7 +9,7 @@ import google.generativeai as genai
 from google.generativeai import types
 
 logger = logging.getLogger(__name__)
-MODEL_NAME = os.getenv("GOOGLE_GENAI_MODEL", "gemini-1.5-pro")
+MODEL_NAME = os.getenv("GOOGLE_GENAI_MODEL", "gemini-2.5-flash")
 
 CLASSIFIER_SYSTEM_INSTRUCTION = (
     "You are an email triage classifier for a busy professional. "


### PR DESCRIPTION
## Summary
- update the backend Gemini model default to `gemini-2.5-flash`
- refresh README and sample env documentation to mention the new default

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cacc8b2464832584a877c1bd6430ce