### PR TITLE
Improve actionable email triage

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,7 @@
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial; margin: 0; padding: 16px; }
     .row { display: flex; gap: 12px; margin-bottom: 12px; }
     .card { border: 1px solid #ddd; border-radius: 12px; padding: 12px; margin-bottom: 10px; }
+    .empty { padding: 24px; text-align: center; color: #666; border: 1px dashed #ccc; border-radius: 12px; }
     .btn { padding: 8px 12px; border-radius: 8px; border: 1px solid #ccc; background: #f8f8f8; cursor: pointer; }
     .btn:active { transform: translateY(1px); }
     #answer { white-space: pre-wrap; }
@@ -30,7 +31,7 @@
   <h3>Answer</h3>
   <div id="answer" class="card"></div>
 
-  <h3>Recent emails</h3>
+  <h3>Needs your reply</h3>
   <div id="emails"></div>
 
   <script type="module" src="/main.js"></script>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite"
+    "dev": "vite",
+    "build": "vite build"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Harden the Gemini classifier to survive empty responses, detect marketing cues, and compute an explicit actionable flag for reply-worthy emails.
- Store and expose only actionable messages from the poller, including updated SSE payloads and a filtered /emails endpoint.
- Refresh the web UI to surface only reply-needed items, add an empty-state message, and provide a production build script.

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cace7b793c832592cb9b1b87e48736