### PR TITLE
Add assistant guidance and chat UI for actionable emails

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,4 +1,14 @@
-from sqlalchemy import Column, Integer, String, Boolean, Float, Text, DateTime, create_engine, select
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Boolean,
+    Float,
+    Text,
+    DateTime,
+    create_engine,
+    text,
+)
 from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy.sql import func
 
@@ -22,9 +32,24 @@ class Email(Base):
     importance_score = Column(Float, default=0.0)
     reply_needed_score = Column(Float, default=0.0)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+    assistant_message = Column(Text, default="")
+    assistant_summary = Column(Text, default="")
+    assistant_reply = Column(Text, default="")
 
 engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
 def init_db():
     Base.metadata.create_all(engine)
+    with engine.begin() as conn:
+        result = conn.execute(text("PRAGMA table_info(emails)"))
+        columns = {row[1] for row in result}
+
+        def ensure_column(name: str, ddl: str) -> None:
+            if name not in columns:
+                conn.execute(text(f"ALTER TABLE emails ADD COLUMN {ddl}"))
+                columns.add(name)
+
+        ensure_column("assistant_message", "assistant_message TEXT DEFAULT ''")
+        ensure_column("assistant_summary", "assistant_summary TEXT DEFAULT ''")
+        ensure_column("assistant_reply", "assistant_reply TEXT DEFAULT ''")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,13 +6,216 @@
   <title>Inbox Buddy</title>
   <link rel="manifest" href="/manifest.json">
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial; margin: 0; padding: 16px; }
-    .row { display: flex; gap: 12px; margin-bottom: 12px; }
-    .card { border: 1px solid #ddd; border-radius: 12px; padding: 12px; margin-bottom: 10px; }
-    .empty { padding: 24px; text-align: center; color: #666; border: 1px dashed #ccc; border-radius: 12px; }
-    .btn { padding: 8px 12px; border-radius: 8px; border: 1px solid #ccc; background: #f8f8f8; cursor: pointer; }
-    .btn:active { transform: translateY(1px); }
-    #answer { white-space: pre-wrap; }
+    :root {
+      color-scheme: light;
+    }
+    body {
+      font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      margin: 0;
+      padding: 24px;
+      background: #f5f7fb;
+      color: #0f172a;
+      min-height: 100vh;
+    }
+    h1 {
+      margin-top: 0;
+      margin-bottom: 16px;
+      font-size: 28px;
+    }
+    .row {
+      display: flex;
+      gap: 12px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+    }
+    .btn {
+      padding: 9px 14px;
+      border-radius: 10px;
+      border: 1px solid #cbd5f5;
+      background: #fff;
+      cursor: pointer;
+      font-weight: 500;
+      transition: transform 0.1s ease, box-shadow 0.1s ease;
+      box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+    }
+    .btn.primary {
+      background: #6366f1;
+      color: #fff;
+      border-color: #4f46e5;
+      box-shadow: 0 1px 3px rgba(79, 70, 229, 0.3);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+    .btn:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+    .layout {
+      display: flex;
+      gap: 24px;
+      flex-wrap: wrap;
+      margin-top: 24px;
+    }
+    .chat-panel {
+      flex: 1 1 380px;
+      max-width: 720px;
+      background: #fff;
+      border: 1px solid #e0e7ff;
+      border-radius: 18px;
+      box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+      padding: 22px;
+      display: flex;
+      flex-direction: column;
+      min-height: 520px;
+    }
+    .chat-panel h2 {
+      margin: 0 0 12px;
+    }
+    .chat-log {
+      flex: 1;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      padding-right: 4px;
+    }
+    .bubble {
+      max-width: 85%;
+      padding: 12px 16px;
+      border-radius: 16px;
+      line-height: 1.45;
+      font-size: 15px;
+      box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+      background: #fff;
+      border: 1px solid transparent;
+    }
+    .bubble-text {
+      white-space: pre-wrap;
+    }
+    .bubble.assistant {
+      background: #eef2ff;
+      border-color: #c7d2fe;
+      align-self: flex-start;
+      border-top-left-radius: 4px;
+    }
+    .bubble.user {
+      background: #dcfce7;
+      border-color: #bbf7d0;
+      align-self: flex-end;
+      border-top-right-radius: 4px;
+    }
+    .bubble.error {
+      background: #fee2e2;
+      border-color: #fca5a5;
+    }
+    .bubble-title {
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+    .bubble-meta {
+      font-size: 12px;
+      color: #475569;
+      margin-bottom: 6px;
+    }
+    .bubble-summary {
+      margin: 10px 0 0 18px;
+      color: #1e293b;
+    }
+    .bubble-summary li {
+      margin-bottom: 4px;
+    }
+    .bubble-reply {
+      background: #ffffff;
+      border: 1px solid #c7d2fe;
+      border-radius: 12px;
+      padding: 12px;
+      margin-top: 10px;
+      white-space: pre-wrap;
+      font-family: "IBM Plex Mono", "Courier New", monospace;
+      font-size: 13px;
+    }
+    .chat-input {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin-top: 16px;
+    }
+    .chat-input textarea {
+      resize: vertical;
+      min-height: 84px;
+      border-radius: 12px;
+      border: 1px solid #cbd5f5;
+      padding: 10px 12px;
+      font-family: inherit;
+      font-size: 15px;
+      line-height: 1.45;
+    }
+    .chat-input textarea:focus {
+      outline: 2px solid #6366f1;
+      border-color: #6366f1;
+    }
+    .list-panel {
+      flex: 1 1 300px;
+      max-width: 520px;
+    }
+    .email-card {
+      border: 1px solid #e2e8f0;
+      background: #fff;
+      border-radius: 16px;
+      padding: 16px;
+      margin-bottom: 12px;
+      box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+    }
+    .email-card .email-date {
+      font-size: 12px;
+      color: #64748b;
+      margin: 6px 0;
+    }
+    .email-card .email-scores {
+      font-size: 12px;
+      color: #475569;
+      margin-top: 10px;
+      font-weight: 500;
+    }
+    .email-card .assistant-note {
+      background: #eef2ff;
+      border-radius: 12px;
+      padding: 10px 12px;
+      margin-top: 10px;
+    }
+    .email-card .assistant-summary {
+      margin: 10px 0 0 18px;
+    }
+    .email-card .assistant-reply {
+      background: #f8fafc;
+      border-radius: 12px;
+      border: 1px solid #cbd5e1;
+      padding: 12px;
+      white-space: pre-wrap;
+      font-size: 13px;
+      margin-top: 10px;
+    }
+    .empty {
+      padding: 24px;
+      text-align: center;
+      color: #475569;
+      border: 1px dashed #cbd5f5;
+      border-radius: 12px;
+      background: #f8fafc;
+    }
+    @media (max-width: 900px) {
+      body {
+        padding: 20px 16px 32px;
+      }
+      .layout {
+        flex-direction: column;
+      }
+      .chat-panel,
+      .list-panel {
+        max-width: none;
+      }
+    }
   </style>
 </head>
 <body>
@@ -23,16 +226,21 @@
     <button id="refresh" class="btn">Refresh Emails</button>
   </div>
 
-  <div class="row">
-    <input id="question" placeholder="Ask about your inbox..." style="flex:1; padding:8px; border-radius:8px; border:1px solid #ccc;">
-    <button id="ask" class="btn">Ask</button>
+  <div class="layout">
+    <section class="chat-panel">
+      <h2>Inbox Buddy Assistant</h2>
+      <div id="chatLog" class="chat-log"></div>
+      <div class="chat-input">
+        <textarea id="chatInput" placeholder="Ask Inbox Buddy about your inbox or request help drafting a reply..."></textarea>
+        <button id="sendChat" class="btn primary">Send</button>
+      </div>
+    </section>
+
+    <section class="list-panel">
+      <h2>Needs your reply</h2>
+      <div id="emails"></div>
+    </section>
   </div>
-
-  <h3>Answer</h3>
-  <div id="answer" class="card"></div>
-
-  <h3>Needs your reply</h3>
-  <div id="emails"></div>
 
   <script type="module" src="/main.js"></script>
 </body>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,96 +1,338 @@
 const API = import.meta.env.VITE_API_BASE || "http://localhost:8000";
 
-async function jget(path){
-  const r = await fetch(API + path);
-  if(!r.ok) throw new Error(await r.text());
-  return r.json();
-}
-async function jpost(path, body){
-  const r = await fetch(API + path, {
-    method: "POST",
-    headers: {"Content-Type":"application/json"},
-    body: JSON.stringify(body)
-  });
-  if(!r.ok) throw new Error(await r.text());
-  return r.json();
+async function jget(path) {
+  const res = await fetch(API + path);
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
 }
 
-async function loadEmails(){
-  const emails = await jget("/emails?limit=50&actionable_only=true");
+async function jpost(path, body) {
+  const res = await fetch(API + path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+const chatLog = document.getElementById("chatLog");
+const chatInput = document.getElementById("chatInput");
+const sendButton = document.getElementById("sendChat");
+
+function addMessage(role, text, extras = {}) {
+  const bubble = document.createElement("div");
+  bubble.className = `bubble ${role}`;
+  if (extras.error) {
+    bubble.classList.add("error");
+  }
+
+  if (extras.title) {
+    const title = document.createElement("div");
+    title.className = "bubble-title";
+    title.textContent = extras.title;
+    bubble.appendChild(title);
+  }
+
+  if (extras.meta) {
+    const meta = document.createElement("div");
+    meta.className = "bubble-meta";
+    meta.textContent = extras.meta;
+    bubble.appendChild(meta);
+  }
+
+  if (text) {
+    const body = document.createElement("div");
+    body.className = "bubble-text";
+    body.textContent = text;
+    bubble.appendChild(body);
+  }
+
+  const summaryItems = Array.isArray(extras.summary)
+    ? extras.summary
+    : [];
+  if (summaryItems.length) {
+    const list = document.createElement("ul");
+    list.className = "bubble-summary";
+    for (const item of summaryItems) {
+      const li = document.createElement("li");
+      li.textContent = item;
+      list.appendChild(li);
+    }
+    bubble.appendChild(list);
+  }
+
+  if (extras.reply) {
+    const pre = document.createElement("pre");
+    pre.className = "bubble-reply";
+    pre.textContent = extras.reply;
+    bubble.appendChild(pre);
+  }
+
+  chatLog.appendChild(bubble);
+  chatLog.scrollTop = chatLog.scrollHeight;
+}
+
+function normalizeSummary(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => String(item || "").trim())
+      .filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(/\r?\n+/)
+      .map((line) => line.replace(/^[\s*•-]+/, "").trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+async function loadEmails() {
   const el = document.getElementById("emails");
   el.innerHTML = "";
-  if(emails.length === 0){
+  let emails = [];
+  try {
+    emails = await jget("/emails?limit=50&actionable_only=true");
+  } catch (err) {
+    addMessage(
+      "assistant",
+      "I couldn't load your actionable emails. Please try refreshing.",
+      { error: true }
+    );
+    return;
+  }
+
+  if (emails.length === 0) {
     const empty = document.createElement("div");
     empty.className = "empty";
     empty.textContent = "You're all caught up. No replies are needed right now.";
     el.appendChild(empty);
     return;
   }
-  for(const e of emails){
+
+  for (const e of emails) {
     const card = document.createElement("div");
-    card.className = "card";
-    card.innerHTML = `
-      <div><b>${e.subject || "(no subject)"}</b></div>
-      <div>From: ${e.sender}</div>
-      <div><i>${new Date(parseInt(e.internal_date || 0)).toLocaleString()}</i></div>
-      <div>${e.snippet}</div>
-      <div>Reply needed score: ${(e.reply_needed_score ?? 0).toFixed(2)} | Importance score: ${(e.importance_score ?? 0).toFixed(2)}</div>
-    `;
+    card.className = "email-card";
+
+    const subjectRow = document.createElement("div");
+    const subjectStrong = document.createElement("strong");
+    subjectStrong.textContent = e.subject || "(no subject)";
+    subjectRow.appendChild(subjectStrong);
+    card.appendChild(subjectRow);
+
+    const senderRow = document.createElement("div");
+    senderRow.textContent = `From: ${e.sender}`;
+    card.appendChild(senderRow);
+
+    if (e.internal_date) {
+      const dateRow = document.createElement("div");
+      dateRow.className = "email-date";
+      dateRow.textContent = new Date(Number(e.internal_date)).toLocaleString();
+      card.appendChild(dateRow);
+    }
+
+    if (e.snippet) {
+      const snippetRow = document.createElement("div");
+      snippetRow.textContent = e.snippet;
+      card.appendChild(snippetRow);
+    }
+
+    const scoresRow = document.createElement("div");
+    scoresRow.className = "email-scores";
+    const replyScore = Number(e.reply_needed_score ?? 0).toFixed(2);
+    const importanceScore = Number(e.importance_score ?? 0).toFixed(2);
+    scoresRow.textContent = `Reply score ${replyScore} · Importance ${importanceScore}`;
+    card.appendChild(scoresRow);
+
+    if (e.assistant_message) {
+      const note = document.createElement("div");
+      note.className = "assistant-note";
+      note.textContent = e.assistant_message;
+      card.appendChild(note);
+    }
+
+    const summary = normalizeSummary(e.assistant_summary);
+    if (summary.length) {
+      const list = document.createElement("ul");
+      list.className = "assistant-summary";
+      for (const item of summary) {
+        const li = document.createElement("li");
+        li.textContent = item;
+        list.appendChild(li);
+      }
+      card.appendChild(list);
+    }
+
+    if (e.assistant_reply) {
+      const pre = document.createElement("pre");
+      pre.className = "assistant-reply";
+      pre.textContent = e.assistant_reply;
+      card.appendChild(pre);
+    }
+
     el.appendChild(card);
   }
 }
 
-async function ask(){
-  const q = document.getElementById("question").value;
-  if(!q) return;
-  const res = await jpost("/ask",{question:q, limit:100});
-  document.getElementById("answer").textContent = res.answer;
+let sending = false;
+
+async function sendChat() {
+  if (sending) return;
+  const message = chatInput.value.trim();
+  if (!message) return;
+
+  addMessage("user", message);
+  chatInput.value = "";
+  sending = true;
+  sendButton.disabled = true;
+
+  try {
+    const res = await jpost("/ask", { question: message, limit: 100 });
+    const answer = (res.answer || "I couldn't find anything helpful just yet.").trim();
+    addMessage("assistant", answer);
+  } catch (err) {
+    console.error(err);
+    addMessage(
+      "assistant",
+      "Sorry, I ran into an error while checking your inbox: " + err.message,
+      { error: true }
+    );
+  } finally {
+    sending = false;
+    sendButton.disabled = false;
+    chatInput.focus();
+  }
 }
 
-async function enableNotifs(){
+async function enableNotifs() {
+  if (!("Notification" in window)) {
+    alert("Notifications are not supported in this browser.");
+    return;
+  }
   const perm = await Notification.requestPermission();
-  if(perm !== "granted"){
+  if (perm !== "granted") {
     alert("Notifications not granted");
   }
 }
 
-function connectSSE(){
-  const ev = new EventSource(API + "/events");
-  ev.onmessage = (m)=>{
-    try{
-      const data = JSON.parse(m.data);
-      if(data.type === "important_email" && data.actionable){
-        if(Notification.permission === "granted"){
-          new Notification("Reply needed", {
-            body: data.subject + " — " + data.sender
-          });
-        }
-      }
-      if(data.type === "error"){
-        console.warn("Server error:", data.message);
-      }
-    }catch(e){}
-  };
+function addAssistantAlert(data) {
+  const summary = normalizeSummary(data.assistant_summary);
+  const replyDraft = typeof data.assistant_reply === "string"
+    ? data.assistant_reply.trim()
+    : "";
+  const message = (data.assistant_message || "").trim() ||
+    `You have an actionable email from ${data.sender || "someone"}.`;
+
+  const metaParts = [];
+  if (data.subject) metaParts.push(`Subject: ${data.subject}`);
+  if (data.reply_needed_score !== undefined && data.importance_score !== undefined) {
+    metaParts.push(
+      `Scores — reply ${(Number(data.reply_needed_score) || 0).toFixed(2)}, ` +
+      `importance ${(Number(data.importance_score) || 0).toFixed(2)}`
+    );
+  }
+
+  addMessage("assistant", message, {
+    title: `New email from ${data.sender || "Someone"}`,
+    meta: metaParts.join(" • ") || undefined,
+    summary,
+    reply: replyDraft,
+  });
 }
 
+function connectSSE() {
+  let announced = false;
+  let errorNotified = false;
+  const source = new EventSource(API + "/events");
+
+  source.onopen = () => {
+    errorNotified = false;
+    if (!announced) {
+      addMessage(
+        "assistant",
+        "I'm connected to Gmail updates. I'll ping you when something needs attention."
+      );
+      announced = true;
+    }
+  };
+
+  source.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      if (data.type === "important_email" && data.actionable) {
+        addAssistantAlert(data);
+        if ("Notification" in window && Notification.permission === "granted") {
+          const body = (data.assistant_message || `${data.subject || "(no subject)"} — ${data.sender || ""}`)
+            .slice(0, 140);
+          new Notification("Reply needed", {
+            body,
+          });
+        }
+        loadEmails();
+      } else if (data.type === "auth_required") {
+        addMessage(
+          "assistant",
+          "Please connect Gmail so I can keep watching for new messages.",
+          { error: true }
+        );
+      } else if (data.type === "error") {
+        addMessage(
+          "assistant",
+          `I ran into an error while polling Gmail: ${data.message}`,
+          { error: true }
+        );
+      }
+    } catch (err) {
+      console.warn("Failed to parse SSE payload", err);
+    }
+  };
+
+  source.onerror = () => {
+    if (!errorNotified) {
+      addMessage(
+        "assistant",
+        "I lost connection to Gmail updates. I'll retry automatically.",
+        { error: true }
+      );
+      errorNotified = true;
+    }
+  };
+
+  return source;
+}
+
+sendButton.onclick = sendChat;
+chatInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter" && !event.shiftKey) {
+    event.preventDefault();
+    sendChat();
+  }
+});
+
 document.getElementById("refresh").onclick = loadEmails;
-document.getElementById("ask").onclick = ask;
 document.getElementById("enableNotifs").onclick = enableNotifs;
 document.getElementById("connect").onclick = () =>
   jget("/auth/start")
-    .then(res => {
-      if(res.already_authenticated){
+    .then((res) => {
+      if (res.already_authenticated) {
         alert("Gmail is already connected.");
         return;
       }
-      if(res.auth_url){
+      if (res.auth_url) {
         window.open(res.auth_url, "_blank", "noopener,noreferrer");
         alert("Complete Google login in the opened tab, then return here.");
         return;
       }
       alert("Authentication response received.");
     })
-    .catch(e => alert(e.message));
+    .catch((e) => alert(e.message));
+
+addMessage(
+  "assistant",
+  "Hi! I'm Inbox Buddy. Ask me about your inbox or wait for me to nudge you when a reply is needed."
+);
 
 loadEmails();
 connectSSE();


### PR DESCRIPTION
## Summary
- capture assistant-ready context when classifying emails and generate personalized reply guidance alongside the original triage data
- store and expose assistant messaging fields in the database, SSE events, and the emails API so clients can surface tailored prompts
- redesign the frontend into a chat-first assistant experience with live notifications, suggested replies, and actionable email cards

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cad150220c8325879ef2e2e2d86b67