### PR TITLE
Handle blocked QA responses gracefully

### DIFF
--- a/backend/triage.py
+++ b/backend/triage.py
@@ -722,7 +722,15 @@ def answer_question(context_text: str, question: str) -> str:
         [{"role": "user", "parts": [prompt]}],
         generation_config=QA_GENERATION_CONFIG,
     )
-    answer = (response.text or "").strip()
+    try:
+        answer = (response.text or "").strip()
+    except ValueError:  # pragma: no cover - SDK defensive path
+        logger.debug("response.text accessor unavailable for QA output")
+        answer = ""
+    if not answer:
+        answer = _response_to_text(response)
+    if not answer:
+        answer = "I'm not sure."
     logger.debug("Answer produced (chars=%d)", len(answer))
     return answer
 


### PR DESCRIPTION
## Summary
- handle `response.text` ValueError in the QA path by falling back to parsed candidates and defaulting to a safe reply
- add regression tests covering blocked QA responses and empty fallbacks

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68cc274385a88325942a2e6edbf3b077