### PR TITLE
Add reset endpoint and improve marketing filtering

### DIFF
--- a/backend/tests/test_triage.py
+++ b/backend/tests/test_triage.py
@@ -71,6 +71,27 @@ def test_looks_like_marketing_detects_roundup_subject():
     assert _looks_like_marketing(email_text) is True
 
 
+def test_looks_like_marketing_detects_advertisement_disclaimer():
+    email_text = (
+        "From: Promo Alerts <ads@example.com>\n"
+        "Subject: Member exclusive offer just for you\n\n"
+        "This email is an advertisement from Promo Alerts.\n"
+        "You are receiving this email because you subscribed to our deals."
+    )
+
+    assert _looks_like_marketing(email_text) is True
+
+
+def test_looks_like_marketing_detects_sponsored_language():
+    email_text = (
+        "From: Travel Partners <hello@example.com>\n"
+        "Subject: A paid partnership highlight\n\n"
+        "Enjoy this sponsored message from our brand partners about upcoming getaways."
+    )
+
+    assert _looks_like_marketing(email_text) is True
+
+
 def test_looks_like_marketing_flags_newsletter_issue_header():
     email_text = textwrap.dedent(
         """

--- a/backend/triage.py
+++ b/backend/triage.py
@@ -252,6 +252,14 @@ def _looks_like_marketing(email_text: str) -> bool:
         "discount",
         "coupon",
         "promo code",
+        "advertisement",
+        "this advertisement",
+        "sponsored",
+        "sponsor",
+        "partner offer",
+        "paid partnership",
+        "paid promotion",
+        "promotional email",
         "book now",
         "rent a car",
         "loyalty",
@@ -269,12 +277,25 @@ def _looks_like_marketing(email_text: str) -> bool:
         "view online",
         "privacy policy",
         "no longer wish to receive",
+        "why am i receiving",
+        "you received this email because",
+        "you are receiving this email because",
+        "you received this because",
         "newsletter",
         "digest",
         "webinar",
         "flash sale",
     )
+    marketing_regexes = (
+        r"\bthis (?:email|message) (?:is|was) (?:an )?advertisement\b",
+        r"\bpaid (?:partner|partnership|promotion)\b",
+        r"\bpartner(?:ship)? (?:offer|message)\b",
+        r"\bbrand partner\b",
+        r"\bmember exclusive offer\b",
+    )
     if any(cue in lowered for cue in marketing_cues):
+        return True
+    if any(re.search(pattern, lowered) for pattern in marketing_regexes):
         return True
 
     subject = _extract_subject_line(email_text)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -44,6 +44,12 @@
       border-color: #4f46e5;
       box-shadow: 0 1px 3px rgba(79, 70, 229, 0.3);
     }
+    .btn.danger {
+      background: #ef4444;
+      color: #fff;
+      border-color: #dc2626;
+      box-shadow: 0 1px 3px rgba(220, 38, 38, 0.28);
+    }
     .btn:active {
       transform: translateY(1px);
     }
@@ -224,6 +230,7 @@
     <button id="connect" class="btn">Connect Gmail</button>
     <button id="enableNotifs" class="btn">Enable Notifications</button>
     <button id="refresh" class="btn">Refresh Emails</button>
+    <button id="reset" class="btn danger">Reset Inbox</button>
   </div>
 
   <div class="layout">


### PR DESCRIPTION
## Summary
- add a FastAPI reset endpoint and refactor the poller to trigger a fresh scan while skipping promotional Gmail messages
- expose the reset control in the UI so users can clear stored emails and immediately reload actionable results
- expand marketing detection heuristics and tests to better suppress advertisement emails

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68cc40d9618483258af492b2b31e631b