### PR TITLE
Handle duplicates and include read emails in actionable list

### DIFF
--- a/backend/gmail_client.py
+++ b/backend/gmail_client.py
@@ -155,11 +155,16 @@ def get_gmail():
     return service
 
 
-DEFAULT_UNREAD_QUERY = "is:unread newer_than:7d -category:promotions"
+DEFAULT_RECENT_QUERY = "newer_than:7d -category:promotions"
 
 
-def list_recent_unread(service, max_results=25, q: Optional[str] = None):
-    query = q or DEFAULT_UNREAD_QUERY
+def list_recent_messages(
+    service,
+    max_results: int = 25,
+    q: Optional[str] = None,
+) -> list[dict]:
+    """Return recent Gmail messages, including ones already read."""
+    query = q or DEFAULT_RECENT_QUERY
     res = (
         service.users()
         .messages()

--- a/backend/tests/test_app_emails.py
+++ b/backend/tests/test_app_emails.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import Email, SessionLocal, get_emails  # noqa: E402
+
+
+def _make_email(**kwargs):
+    defaults = {
+        "msg_id": "",
+        "thread_id": "",
+        "subject": "Subject",
+        "sender": "sender@example.com",
+        "snippet": "Snippet",
+        "body": "Body text",
+        "internal_date": 0,
+        "is_unread": True,
+        "is_important": True,
+        "reply_needed": True,
+        "importance_score": 0.8,
+        "reply_needed_score": 0.8,
+    }
+    defaults.update(kwargs)
+    return Email(**defaults)
+
+
+def test_get_emails_dedupes_by_thread_and_keeps_latest():
+    db = SessionLocal()
+    try:
+        db.query(Email).delete()
+
+        db.add_all(
+            [
+                _make_email(
+                    msg_id="m1",
+                    thread_id="thread-1",
+                    subject="Original",
+                    internal_date=100,
+                ),
+                _make_email(
+                    msg_id="m2",
+                    thread_id="thread-1",
+                    subject="Follow up",
+                    internal_date=200,
+                ),
+                _make_email(
+                    msg_id="m3",
+                    thread_id="thread-2",
+                    subject="Different thread",
+                    internal_date=150,
+                ),
+            ]
+        )
+        db.commit()
+
+        results = get_emails(limit=10, actionable_only=True)
+
+        assert len(results) == 2
+        assert {item["thread_id"] for item in results} == {"thread-1", "thread-2"}
+        assert results[0]["msg_id"] == "m2"
+        assert results[0]["subject"] == "Follow up"
+    finally:
+        db.query(Email).delete()
+        db.commit()
+        db.close()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -173,6 +173,17 @@
       margin-bottom: 12px;
       box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
     }
+    .email-card .email-status {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      margin-top: 6px;
+      color: #64748b;
+    }
+    .email-card .email-status.unread {
+      color: #2563eb;
+    }
     .email-card .email-date {
       font-size: 12px;
       color: #64748b;

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -127,6 +127,11 @@ async function loadEmails() {
     senderRow.textContent = `From: ${e.sender}`;
     card.appendChild(senderRow);
 
+    const statusRow = document.createElement("div");
+    statusRow.className = "email-status " + (e.is_unread ? "unread" : "read");
+    statusRow.textContent = e.is_unread ? "Unread" : "Read";
+    card.appendChild(statusRow);
+
     if (e.internal_date) {
       const dateRow = document.createElement("div");
       dateRow.className = "email-date";


### PR DESCRIPTION
## Summary
- dedupe actionable email responses by thread and persist the unread flag from Gmail for each message
- poll Gmail for recent read messages as well as unread ones and surface their status in the UI cards
- add a regression test to ensure only the latest actionable email per thread is returned

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc446365748325a4df5ef4426f22a5